### PR TITLE
Add GEX commentary parsing and alerts

### DIFF
--- a/signal_pipeline/gex_parser.py
+++ b/signal_pipeline/gex_parser.py
@@ -1,0 +1,16 @@
+GEX_TRIGGERS = {
+    "support_terms": ["", "support", "dip zone", "buy wall"],
+    "resistance_terms": ["", "resistance", "rip zone", "sell wall"],
+    "gamma_break_terms": ["gamma break", "snap zone", "vol zone"],
+    "cluster_weakness_terms": ["weak cluster", "fragile", "thin gamma"],
+    "macro_overlay_terms": ["FOMC", "tariff", "earnings", "CPI"]
+}
+
+
+def parse_gex_comment(text: str):
+    text = text.lower()
+    return {
+        "gamma_break_near": any(term.lower() in text for term in GEX_TRIGGERS["gamma_break_terms"]),
+        "fragile_containment": any(term.lower() in text for term in GEX_TRIGGERS["cluster_weakness_terms"]),
+        "macro_risk_overlay": any(term.lower() in text for term in GEX_TRIGGERS["macro_overlay_terms"])
+    }

--- a/signal_pipeline/streamlit_signal_dashboard.py
+++ b/signal_pipeline/streamlit_signal_dashboard.py
@@ -53,7 +53,13 @@ else:
         if row.get('xrt_si_spike'): score += 1
         if row.get('xrt_redemptions'): score += 1
         if row.get('regsho_flag'): score += 1
-        return score
+        if row.get('gamma_break_warning'): score += 1
+        if row.get('containment_fragile'): score += 1
+        if row.get('macro_vol_risk'): score += 1
+        score_modifier = 0
+        if row.get('gamma_break_warning') and row.get('containment_fragile'):
+            score_modifier += 0.1
+        return score + score_modifier
 
     df["signal_score"] = df.apply(compute_threat_level, axis=1)
     df["alert_level"] = df["signal_score"].apply(
@@ -95,6 +101,12 @@ else:
             - 🧠 Sentiment Score: `{row['sentiment_score']:.2f}`
             - 🔻 RegSHO: `{row['regsho_flag']}`, ETF Compression: `{row['xrt_si_spike']}` / `{row['xrt_redemptions']}`
             """)
+            if row.get('gamma_break_warning'):
+                st.warning("Gamma Break Zone Nearby – Watch for reflexive volatility.")
+            if row.get('containment_fragile'):
+                st.info("Weak Gamma Clusters Detected – Suppression may not hold.")
+            if row.get('macro_vol_risk'):
+                st.error("Macro Catalyst Risk Overlay Active – FOMC or earnings this week.")
 
     # Analytics
     if show_analytics:

--- a/tests/test_gex_parser.py
+++ b/tests/test_gex_parser.py
@@ -1,0 +1,18 @@
+import unittest
+from signal_pipeline.gex_parser import parse_gex_comment
+
+class TestGEXParser(unittest.TestCase):
+    def test_gamma_break_detected(self):
+        text = "Massive snap zone indicates a gamma break ahead"
+        res = parse_gex_comment(text)
+        self.assertTrue(res["gamma_break_near"])
+        self.assertFalse(res["fragile_containment"])
+        self.assertFalse(res["macro_risk_overlay"])
+
+    def test_cluster_weakness_detected(self):
+        text = "Thin gamma means a very weak cluster forming"
+        res = parse_gex_comment(text)
+        self.assertTrue(res["fragile_containment"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `gex_parser` module with keywords and `parse_gex_comment`
- parse Reddit text in `scan_volatility_signals` and add new flags
- raise Streamlit dashboard scores and warnings when gamma break or fragile containment detected
- include unit tests for the parser

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6887c731c0488323a7e01551bc1b4c25