### PR TITLE
Fix gex parser import

### DIFF
--- a/signal_pipeline/scan_volatility_signals.py
+++ b/signal_pipeline/scan_volatility_signals.py
@@ -9,7 +9,7 @@ import logging
 import argparse
 import sys
 from typing import List, Dict, Tuple
-from gex_parser import parse_gex_comment
+from .gex_parser import parse_gex_comment
 try:
     from textblob import TextBlob
     TEXTBLOB_AVAILABLE = True


### PR DESCRIPTION
## Summary
- use a relative import for `parse_gex_comment`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d2cc4ea083239650950f41e5d149