### PR TITLE
Fix alert level rounding

### DIFF
--- a/signal_pipeline/alert_utils.py
+++ b/signal_pipeline/alert_utils.py
@@ -1,0 +1,16 @@
+# Utility functions for alert level calculations
+
+def classify_alert_level(score):
+    """Return the alert level emoji string for a given score.
+
+    The score may be fractional. It is rounded to the nearest integer
+    before classification so that small adjustments do not lead to
+    unexpected alert levels.
+    """
+    rounded = round(score)
+    if rounded <= 1:
+        return "🟢 Watch"
+    elif rounded == 2:
+        return "🟡 Tension"
+    else:
+        return "🔴 Breakout Potential"

--- a/signal_pipeline/streamlit_signal_dashboard.py
+++ b/signal_pipeline/streamlit_signal_dashboard.py
@@ -3,6 +3,7 @@ import pandas as pd
 import json
 import os
 from datetime import date
+from signal_pipeline.alert_utils import classify_alert_level
 
 # Load today's alert file
 def load_alerts():
@@ -62,9 +63,7 @@ else:
         return score + score_modifier
 
     df["signal_score"] = df.apply(compute_threat_level, axis=1)
-    df["alert_level"] = df["signal_score"].apply(
-        lambda x: "🟢 Watch" if x <= 1 else "🟡 Tension" if x == 2 else "🔴 Breakout Potential"
-    )
+    df["alert_level"] = df["signal_score"].apply(classify_alert_level)
 
     # Filtering
     filtered_df = df.copy()

--- a/tests/test_alert_level.py
+++ b/tests/test_alert_level.py
@@ -1,0 +1,12 @@
+import unittest
+from signal_pipeline.alert_utils import classify_alert_level
+
+class TestAlertLevel(unittest.TestCase):
+    def test_fractional_classification(self):
+        self.assertEqual(classify_alert_level(1.1), "🟢 Watch")
+        self.assertEqual(classify_alert_level(2.0), "🟡 Tension")
+        self.assertEqual(classify_alert_level(2.2), "🟡 Tension")
+        self.assertEqual(classify_alert_level(2.6), "🔴 Breakout Potential")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- import a new alert util for classifying scores
- round scores before alert-level comparison
- test alert-level classification with fractional values

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d2ce6450832392e8a58fd7cb35f2