### PR TITLE
Add support/resistance parsing to GEX comment parser

### DIFF
--- a/signal_pipeline/gex_parser.py
+++ b/signal_pipeline/gex_parser.py
@@ -1,6 +1,8 @@
 GEX_TRIGGERS = {
-    "support_terms": ["", "support", "dip zone", "buy wall"],
-    "resistance_terms": ["", "resistance", "rip zone", "sell wall"],
+    # terms describing potential support zones or buy walls
+    "support_terms": ["support", "dip zone", "buy wall"],
+    # terms describing potential resistance zones or sell walls
+    "resistance_terms": ["resistance", "rip zone", "sell wall"],
     "gamma_break_terms": ["gamma break", "snap zone", "vol zone"],
     "cluster_weakness_terms": ["weak cluster", "fragile", "thin gamma"],
     "macro_overlay_terms": ["FOMC", "tariff", "earnings", "CPI"]
@@ -10,6 +12,12 @@ GEX_TRIGGERS = {
 def parse_gex_comment(text: str):
     text = text.lower()
     return {
+        "support_discussed": any(
+            term.lower() in text for term in GEX_TRIGGERS["support_terms"]
+        ),
+        "resistance_discussed": any(
+            term.lower() in text for term in GEX_TRIGGERS["resistance_terms"]
+        ),
         "gamma_break_near": any(term.lower() in text for term in GEX_TRIGGERS["gamma_break_terms"]),
         "fragile_containment": any(term.lower() in text for term in GEX_TRIGGERS["cluster_weakness_terms"]),
         "macro_risk_overlay": any(term.lower() in text for term in GEX_TRIGGERS["macro_overlay_terms"])

--- a/tests/test_gex_parser.py
+++ b/tests/test_gex_parser.py
@@ -6,6 +6,8 @@ class TestGEXParser(unittest.TestCase):
         text = "Massive snap zone indicates a gamma break ahead"
         res = parse_gex_comment(text)
         self.assertTrue(res["gamma_break_near"])
+        self.assertFalse(res["support_discussed"])
+        self.assertFalse(res["resistance_discussed"])
         self.assertFalse(res["fragile_containment"])
         self.assertFalse(res["macro_risk_overlay"])
 
@@ -13,6 +15,17 @@ class TestGEXParser(unittest.TestCase):
         text = "Thin gamma means a very weak cluster forming"
         res = parse_gex_comment(text)
         self.assertTrue(res["fragile_containment"])
+
+    def test_support_and_resistance_detection(self):
+        support_text = "Expecting a bounce off the dip zone support"
+        resistance_text = "There's a major sell wall acting as resistance"
+        support_res = parse_gex_comment(support_text)
+        resistance_res = parse_gex_comment(resistance_text)
+
+        self.assertTrue(support_res["support_discussed"])
+        self.assertFalse(support_res["resistance_discussed"])
+        self.assertTrue(resistance_res["resistance_discussed"])
+        self.assertFalse(resistance_res["support_discussed"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add detection of support/resistance terms in `parse_gex_comment`
- remove empty placeholders from term lists
- test support and resistance detection

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6887d2cf42808323b095d6cc9b99d395