### PR TITLE
Add sentiment scoring module and fix import

### DIFF
--- a/sentiment_score.py
+++ b/sentiment_score.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper exposing sentiment scoring utilities at project root."""
+
+from signal_pipeline.sentiment_score import *  # re-export

--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -10,12 +10,7 @@ import matplotlib.pyplot as plt
 import argparse
 import json
 
-try:
-    from sentiment_score import classify_sentiment
-except ImportError:
-    def classify_sentiment(text):
-        # Dummy fallback: returns neutral polarity and label
-        return 0.0, 'neutral'
+from sentiment_score import classify_sentiment
 
 from functools import lru_cache
 


### PR DESCRIPTION
## Summary
- implement a top-level `sentiment_score` wrapper so other modules can import it
- use `sentiment_score.classify_sentiment` directly in `vol_container_score`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688803dcfaec832389be1a3ab52afda7