### PR TITLE
Centralized dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cp signal_pipeline/.env.template .env
 # edit .env and supply credentials
 ```
 
+The resulting `.env` file must live in the project root (same directory as this
+README) so all scripts can load your environment variables automatically.
+
 Keys are required for Reddit (and optional market data providers).
 
 ## Quick Start

--- a/signal_pipeline/config.py
+++ b/signal_pipeline/config.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from dotenv import load_dotenv
+
+_loaded = False
+
+def load_env(env_path: str | None = None) -> None:
+    """Load environment variables from a .env file once."""
+    global _loaded
+    if _loaded:
+        return
+    if env_path is None:
+        # default to project root .env
+        root_dir = Path(__file__).resolve().parents[1]
+        env_path = root_dir / ".env"
+    load_dotenv(env_path)
+    _loaded = True
+

--- a/signal_pipeline/cron_reddit_fetcher.py
+++ b/signal_pipeline/cron_reddit_fetcher.py
@@ -5,6 +5,9 @@ import os
 import sys
 import logging
 from datetime import datetime
+from .config import load_env
+
+load_env()
 
 # --- Configurable schedule time ---
 SCHEDULE_TIME = os.environ.get("REDDIT_FETCH_TIME", "08:30")

--- a/signal_pipeline/reddit_scraper.py
+++ b/signal_pipeline/reddit_scraper.py
@@ -2,7 +2,7 @@ import os
 import json
 import praw
 from datetime import datetime
-from dotenv import load_dotenv
+from .config import load_env
 import logging
 import argparse
 import time
@@ -22,8 +22,8 @@ logging.basicConfig(
     handlers=[logging.FileHandler("reddit_scraper.log"), logging.StreamHandler()]
 )
 
-# Load environment variables from .env
-load_dotenv()
+# Load environment variables
+load_env()
 
 DEFAULT_SUBREDDITS = ['wallstreetbets', 'GME', 'Superstonk']
 DEFAULT_LIMIT = 100

--- a/signal_pipeline/scan_volatility_signals.py
+++ b/signal_pipeline/scan_volatility_signals.py
@@ -9,7 +9,10 @@ import logging
 import argparse
 import sys
 from typing import List, Dict, Tuple
+from .config import load_env
 from .gex_parser import parse_gex_comment
+
+load_env()
 try:
     from textblob import TextBlob
     TEXTBLOB_AVAILABLE = True

--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -9,8 +9,11 @@ import os
 import matplotlib.pyplot as plt
 import argparse
 import json
+from .config import load_env
 
 from sentiment_score import classify_sentiment
+
+load_env()
 
 from functools import lru_cache
 


### PR DESCRIPTION
## Summary
- add `load_env()` helper that loads `.env` once
- update scripts to load environment vars via `load_env`
- document `.env` file location

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880aabd8688323af7ff078b56c6817