### PR TITLE
Add unified configuration loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ cp signal_pipeline/.env.template .env
 
 Keys are required for Reddit (and optional market data providers).
 
+### Unified Configuration
+
+Runtime settings are loaded via `signal_pipeline.config.load_config()` which
+combines variables defined in `.env` with defaults from `config.json` located at
+the repository root. Values in the environment always take precedence.
+
 ## Quick Start
 
 Run the scoring scripts sequentially:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,19 @@
+{
+  "REDDIT_CLIENT_ID": "",
+  "REDDIT_CLIENT_SECRET": "",
+  "REDDIT_USER_AGENT": "volcon-lab",
+  "FINNHUB_API_KEY": "",
+  "NEWSAPI_KEY": "",
+  "ALERT_EMAIL": "",
+  "SMTP_SERVER": "smtp.example.com",
+  "SMTP_PORT": 465,
+  "SMTP_USER": "",
+  "SMTP_PASS": "",
+  "TICKERS": ["GME", "AMC"],
+  "ETF_TICKER": "XRT",
+  "REGSHO_LIST_URL": "https://example.com/regsho/latest.txt",
+  "SENTIMENT_PATH_TEMPLATE": "reddit/{ticker}/{date}/posts.json",
+  "ALERTS_DIR": "alerts",
+  "REDDIT_FETCH_TIME": "08:30",
+  "REDDIT_FETCH_MAX_RETRIES": 3
+}

--- a/signal_pipeline/config.py
+++ b/signal_pipeline/config.py
@@ -1,0 +1,30 @@
+import json
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_config(path: str | os.PathLike | None = None) -> dict:
+    """Load configuration combining `.env` and JSON defaults."""
+    env_path = _REPO_ROOT / '.env'
+    if env_path.exists():
+        load_dotenv(env_path)
+    else:
+        load_dotenv()
+
+    cfg_path = Path(path) if path else _REPO_ROOT / 'config.json'
+    defaults: dict = {}
+    if cfg_path.exists():
+        try:
+            with open(cfg_path) as f:
+                defaults = json.load(f)
+        except Exception:
+            defaults = {}
+    config = defaults.copy()
+    for key, value in os.environ.items():
+        if key.isupper():
+            config[key] = value
+    return config

--- a/signal_pipeline/cron_reddit_fetcher.py
+++ b/signal_pipeline/cron_reddit_fetcher.py
@@ -2,13 +2,15 @@ import schedule
 import time
 import subprocess
 import os
+from .config import load_config
 import sys
 import logging
 from datetime import datetime
 
 # --- Configurable schedule time ---
-SCHEDULE_TIME = os.environ.get("REDDIT_FETCH_TIME", "08:30")
-MAX_RETRIES = int(os.environ.get("REDDIT_FETCH_MAX_RETRIES", 3))
+CONFIG = load_config()
+SCHEDULE_TIME = CONFIG.get("REDDIT_FETCH_TIME", "08:30")
+MAX_RETRIES = int(CONFIG.get("REDDIT_FETCH_MAX_RETRIES", 3))
 
 logging.basicConfig(
     level=logging.INFO,

--- a/signal_pipeline/reddit_scraper.py
+++ b/signal_pipeline/reddit_scraper.py
@@ -2,13 +2,13 @@ import os
 import json
 import praw
 from datetime import datetime
-from dotenv import load_dotenv
 import logging
 import argparse
 import time
 from typing import List, Dict, Any, Optional
 from tqdm import tqdm
 import yaml
+from .config import load_config
 try:
     from sentiment_score import classify_sentiment
     SENTIMENT_AVAILABLE = True
@@ -22,25 +22,26 @@ logging.basicConfig(
     handlers=[logging.FileHandler("reddit_scraper.log"), logging.StreamHandler()]
 )
 
-# Load environment variables from .env
-load_dotenv()
+# Load configuration (env values override defaults)
+CONFIG = load_config()
 
 DEFAULT_SUBREDDITS = ['wallstreetbets', 'GME', 'Superstonk']
 DEFAULT_LIMIT = 100
 TICKER_LIST = ['GME', 'AMC', 'TSLA', 'AAPL', 'MSFT', 'NVDA', 'XRT', 'SPY', 'QQQ']  # Example tickers
 
-REDDIT_CLIENT_ID = os.getenv("REDDIT_CLIENT_ID")
-REDDIT_CLIENT_SECRET = os.getenv("REDDIT_CLIENT_SECRET")
-REDDIT_USER_AGENT = os.getenv("REDDIT_USER_AGENT")
+REDDIT_CLIENT_ID = CONFIG.get("REDDIT_CLIENT_ID")
+REDDIT_CLIENT_SECRET = CONFIG.get("REDDIT_CLIENT_SECRET")
+REDDIT_USER_AGENT = CONFIG.get("REDDIT_USER_AGENT")
 
 
-def validate_credentials() -> bool:
+def validate_credentials(cfg: dict = CONFIG) -> bool:
+    """Return True if Reddit credentials are present in cfg."""
     missing = []
-    if not REDDIT_CLIENT_ID:
+    if not cfg.get("REDDIT_CLIENT_ID"):
         missing.append("REDDIT_CLIENT_ID")
-    if not REDDIT_CLIENT_SECRET:
+    if not cfg.get("REDDIT_CLIENT_SECRET"):
         missing.append("REDDIT_CLIENT_SECRET")
-    if not REDDIT_USER_AGENT:
+    if not cfg.get("REDDIT_USER_AGENT"):
         missing.append("REDDIT_USER_AGENT")
     if missing:
         logging.error(f"Missing Reddit API credentials: {', '.join(missing)}")
@@ -80,11 +81,17 @@ def enrich_post(data, tickers):
             data['sentiment_label'] = None
     return data
 
-def log_command(args):
+def log_command(args, cfg: dict = CONFIG):
+    """Log CLI arguments and active credentials."""
     logging.info(f"Command args: {args}")
-    logging.info(f"Environment: CLIENT_ID={REDDIT_CLIENT_ID}, CLIENT_SECRET={'***' if REDDIT_CLIENT_SECRET else None}, USER_AGENT={REDDIT_USER_AGENT}")
+    logging.info(
+        "Environment: CLIENT_ID=%s, CLIENT_SECRET=%s, USER_AGENT=%s",
+        cfg.get("REDDIT_CLIENT_ID"),
+        "***" if cfg.get("REDDIT_CLIENT_SECRET") else None,
+        cfg.get("REDDIT_USER_AGENT"),
+    )
 
-def load_config(config_path):
+def load_scraper_config(config_path):
     if config_path and os.path.exists(config_path):
         with open(config_path, 'r') as f:
             if config_path.endswith('.yaml') or config_path.endswith('.yml'):
@@ -93,19 +100,29 @@ def load_config(config_path):
                 return json.load(f)
     return None
 
-def fetch_posts(subreddits: List[str], limit: int, save_dir: str, retries: int = 3, delay: float = 5.0,
-                min_score: int = 0, exclude_stickied: bool = True, exclude_removed: bool = True,
-                keywords: Optional[List[str]] = None, tickers: Optional[List[str]] = None) -> int:
+def fetch_posts(
+    subreddits: List[str],
+    limit: int,
+    save_dir: str,
+    retries: int = 3,
+    delay: float = 5.0,
+    min_score: int = 0,
+    exclude_stickied: bool = True,
+    exclude_removed: bool = True,
+    keywords: Optional[List[str]] = None,
+    tickers: Optional[List[str]] = None,
+    config: dict = CONFIG,
+) -> int:
     """
     Fetch posts from given subreddits, save to JSON, and return number of posts saved.
     """
-    if not validate_credentials():
+    if not validate_credentials(config):
         return 0
     try:
         reddit = praw.Reddit(
-            client_id=REDDIT_CLIENT_ID,
-            client_secret=REDDIT_CLIENT_SECRET,
-            user_agent=REDDIT_USER_AGENT
+            client_id=config.get("REDDIT_CLIENT_ID"),
+            client_secret=config.get("REDDIT_CLIENT_SECRET"),
+            user_agent=config.get("REDDIT_USER_AGENT"),
         )
     except Exception as e:
         logging.error(f"Error initializing PRAW: {e}")
@@ -186,7 +203,7 @@ def main():
     args = parser.parse_args()
 
     # Config file support
-    config = load_config(args.config)
+    config = load_scraper_config(args.config)
     if config:
         date = config.get('date', args.date)
         subreddits = config.get('subreddits', args.subreddits)
@@ -214,7 +231,7 @@ def main():
         keywords = [k.strip() for k in args.keywords.split(',')] if args.keywords else None
         tickers = [t.strip() for t in args.tickers.split(',')] if args.tickers else None
 
-    log_command(args)
+    log_command(args, CONFIG)
     n_posts = fetch_posts(
         subreddits,
         limit,
@@ -223,7 +240,8 @@ def main():
         exclude_stickied=exclude_stickied,
         exclude_removed=exclude_removed,
         keywords=keywords,
-        tickers=tickers
+        tickers=tickers,
+        config=CONFIG,
     )
     print(f"✅ Saved {n_posts} posts to {save_dir}/posts.json")
 

--- a/signal_pipeline/scan_volatility_signals.py
+++ b/signal_pipeline/scan_volatility_signals.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 from typing import List, Dict, Tuple
 from .gex_parser import parse_gex_comment
+from .config import load_config
 try:
     from textblob import TextBlob
     TEXTBLOB_AVAILABLE = True
@@ -19,24 +20,21 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # --- Config ---
-def load_config():
-    config = {
-        "TICKERS": os.environ.get("TICKERS", "GME,AMC").split(","),
-        "ETF_TICKER": os.environ.get("ETF_TICKER", "XRT"),
-        "REGSHO_LIST_URL": os.environ.get("REGSHO_LIST_URL", "https://example.com/regsho/latest.txt"),
-        # Each ticker has its own reddit dump folder by default
-        "SENTIMENT_PATH_TEMPLATE": os.environ.get("SENTIMENT_PATH_TEMPLATE", "reddit/{ticker}/{date}/posts.json"),
-        "ALERTS_DIR": os.environ.get("ALERTS_DIR", "alerts"),
+def runtime_config(path: str | None = None) -> Dict:
+    """Return merged configuration for this module."""
+    cfg = load_config(path)
+    defaults = {
+        "TICKERS": ["GME", "AMC"],
+        "ETF_TICKER": "XRT",
+        "REGSHO_LIST_URL": "https://example.com/regsho/latest.txt",
+        "SENTIMENT_PATH_TEMPLATE": "reddit/{ticker}/{date}/posts.json",
+        "ALERTS_DIR": "alerts",
     }
-    # Optionally load from config.json
-    if os.path.exists("config.json"):
-        try:
-            with open("config.json") as f:
-                file_cfg = json.load(f)
-            config.update(file_cfg)
-        except Exception as e:
-            logging.warning(f"Failed to load config.json: {e}")
-    return config
+    for k, v in defaults.items():
+        cfg.setdefault(k, v)
+    if isinstance(cfg.get("TICKERS"), str):
+        cfg["TICKERS"] = [t.strip() for t in cfg["TICKERS"].split(",") if t.strip()]
+    return cfg
 
 def load_sentiment_score(ticker: str = "GME", date: datetime.date = None, sentiment_path_template: str = "reddit/{ticker}/{date}/posts.json") -> float:
     """Load sentiment score for a ticker from JSON file. Uses keyword and TextBlob scoring if available."""
@@ -210,7 +208,7 @@ def scan_volatility_signals(
 
 # --- CLI Run ---
 def main():
-    config = load_config()
+    config = runtime_config()
     parser = argparse.ArgumentParser(description="Scan volatility signals for tickers.")
     parser.add_argument("--tickers", type=str, help="Comma-separated tickers", default=','.join(config["TICKERS"]))
     parser.add_argument("--date", type=str, help="Date in YYYY-MM-DD format", default=None)

--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -9,6 +9,9 @@ import os
 import matplotlib.pyplot as plt
 import argparse
 import json
+from .config import load_config
+
+CONFIG = load_config()
 
 from sentiment_score import classify_sentiment
 
@@ -360,7 +363,7 @@ def export_excel(ticker):
         json.dump(stats, f, indent=2)
     print(f"Exported to {excel_path} and summary stats to {stats_path}")
 
-def fetch_news_sentiment(ticker):
+def fetch_news_sentiment(ticker, config: dict = CONFIG):
     """Fetch recent news and compute average sentiment polarity.
 
     The function attempts to use Finnhub if ``FINNHUB_API_KEY`` is set or
@@ -373,8 +376,8 @@ def fetch_news_sentiment(ticker):
         import datetime as _dt
 
         headlines = []
-        if os.environ.get("FINNHUB_API_KEY"):
-            key = os.environ["FINNHUB_API_KEY"]
+        if config.get("FINNHUB_API_KEY"):
+            key = config["FINNHUB_API_KEY"]
             to_d = _dt.date.today()
             from_d = to_d - _dt.timedelta(days=7)
             url = (
@@ -385,8 +388,8 @@ def fetch_news_sentiment(ticker):
             resp.raise_for_status()
             articles = resp.json()
             headlines = [a.get("headline", "") for a in articles]
-        elif os.environ.get("NEWSAPI_KEY"):
-            key = os.environ["NEWSAPI_KEY"]
+        elif config.get("NEWSAPI_KEY"):
+            key = config["NEWSAPI_KEY"]
             url = (
                 f"https://newsapi.org/v2/everything?q={ticker}&pageSize=10"
                 f"&sortBy=publishedAt&apiKey={key}"
@@ -396,7 +399,7 @@ def fetch_news_sentiment(ticker):
             data = resp.json()
             headlines = [a.get("title", "") for a in data.get("articles", [])]
         else:
-            print("No FINNHUB_API_KEY or NEWSAPI_KEY set in environment.")
+            print("No FINNHUB_API_KEY or NEWSAPI_KEY configured.")
             return None
 
         if not headlines:
@@ -412,7 +415,7 @@ def fetch_news_sentiment(ticker):
         print(f"News sentiment fetch error: {e}")
         return None
 
-def load_config(config_path='volcon_config.json'):
+def load_json_config(config_path='volcon_config.json'):
     if os.path.exists(config_path):
         with open(config_path) as f:
             return json.load(f)
@@ -527,13 +530,13 @@ def main():
                     "XRT": {"sector": "ETF", "exchange": "NYSEARCA"}
                 },
                 "api_keys": {
-                    "FINNHUB_API_KEY": os.environ.get('FINNHUB_API_KEY', '')
+                    "FINNHUB_API_KEY": CONFIG.get('FINNHUB_API_KEY', '')
                 }
             }
             with open(args.config, 'w') as f:
                 json.dump(default_config, f, indent=2)
             print(f"Auto-generated config file: {args.config}")
-        config = load_config(args.config)
+        config = load_json_config(args.config)
         validate_config(config)
         weights = config.get('weights')
         tickers = config.get('tickers')
@@ -561,11 +564,11 @@ def main():
             send_email_alert(
                 subject=f"High Vol Container Score Alert: {args.ticker}",
                 body=str(result),
-                to_email=os.environ.get('ALERT_EMAIL', ''),
-                smtp_server=os.environ.get('SMTP_SERVER', ''),
-                smtp_port=int(os.environ.get('SMTP_PORT', 465)),
-                smtp_user=os.environ.get('SMTP_USER', ''),
-                smtp_pass=os.environ.get('SMTP_PASS', '')
+                to_email=CONFIG.get('ALERT_EMAIL', ''),
+                smtp_server=CONFIG.get('SMTP_SERVER', ''),
+                smtp_port=int(CONFIG.get('SMTP_PORT', 465)),
+                smtp_user=CONFIG.get('SMTP_USER', ''),
+                smtp_pass=CONFIG.get('SMTP_PASS', '')
             )
     if args.batch:
         print(batch_score(args.batch, weights))


### PR DESCRIPTION
## Summary
- implement a config loader that merges `.env` and `config.json`
- refactor scripts to use the loader instead of reading `os.environ`
- document unified configuration in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880aaccd60832390ebb54b4e1e1229