### PR TITLE
Add CLI weight overrides

### DIFF
--- a/signal_pipeline/README.md
+++ b/signal_pipeline/README.md
@@ -23,6 +23,16 @@ This folder contains the operational VolCon signal layer for detecting volatilit
    python vol_container_score.py
    ```
 
+### Custom Weights
+
+You can override feature weights directly from the command line.  For example,
+to give IV rank more influence and lower the weight of the RV-IV spread:
+
+```bash
+python vol_container_score.py --ticker GME \
+    --weight_iv_rank 0.4 --weight_rv_iv_spread 0.1
+```
+
 ## Dashboard
 
 Run with:

--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -485,6 +485,11 @@ def main():
     parser.add_argument('--help_all', action='store_true', help='Show help for all features')
     parser.add_argument('--email_alert', action='store_true', help='Send email alert for high scores')
     parser.add_argument('--pdf_report', type=str, help='Generate PDF report for ticker')
+    parser.add_argument('--weight_iv_rank', type=float, help='Override weight for IV rank feature')
+    parser.add_argument('--weight_oi_conc', type=float, help='Override weight for open interest concentration')
+    parser.add_argument('--weight_sentiment', type=float, help='Override weight for sentiment score')
+    parser.add_argument('--weight_ov_ratio', type=float, help='Override weight for option volume ratio')
+    parser.add_argument('--weight_rv_iv_spread', type=float, help='Override weight for RV-IV spread')
     args = parser.parse_args()
 
     if args.help_all:
@@ -502,6 +507,11 @@ def main():
         --dashboard : Launch interactive Streamlit dashboard
         --email_alert : Send email alert for high scores
         --pdf_report [TICKER] : Generate PDF report for ticker
+        --weight_iv_rank [FLOAT] : Override IV rank weight
+        --weight_oi_conc [FLOAT] : Override OI concentration weight
+        --weight_sentiment [FLOAT] : Override sentiment score weight
+        --weight_ov_ratio [FLOAT] : Override option volume ratio weight
+        --weight_rv_iv_spread [FLOAT] : Override RV-IV spread weight
         --help_all : Show this help message
         """)
         return
@@ -542,6 +552,22 @@ def main():
     else:
         metadata = {}
         api_keys = {}
+
+    # Apply CLI weight overrides if provided
+    cli_weights = {}
+    if args.weight_iv_rank is not None:
+        cli_weights['iv_rank'] = args.weight_iv_rank
+    if args.weight_oi_conc is not None:
+        cli_weights['oi_concentration'] = args.weight_oi_conc
+    if args.weight_sentiment is not None:
+        cli_weights['sentiment_score'] = args.weight_sentiment
+    if args.weight_ov_ratio is not None:
+        cli_weights['ov_ratio'] = args.weight_ov_ratio
+    if args.weight_rv_iv_spread is not None:
+        cli_weights['rv_iv_spread'] = args.weight_rv_iv_spread
+    if cli_weights:
+        weights = weights.copy() if weights else {}
+        weights.update(cli_weights)
 
     if args.dashboard:
         try:


### PR DESCRIPTION
## Summary
- add command line options to adjust scoring weights
- build a weight dictionary from CLI inputs and pass to scoring functions
- document weight overrides in signal_pipeline README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880aadd68c8323991102354640c5a0