### PR TITLE
Add pytest coverage for core scoring and sentiment utilities

### DIFF
--- a/signal_pipeline/config.py
+++ b/signal_pipeline/config.py
@@ -1,9 +1,7 @@
-codex/implement-unified-configuration-loader
 import json
 import os
 from pathlib import Path
 from dotenv import load_dotenv
-
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -29,11 +27,10 @@ def load_config(path: str | os.PathLike | None = None) -> dict:
         if key.isupper():
             config[key] = value
     return config
-=======
-from pathlib import Path
-from dotenv import load_dotenv
+
 
 _loaded = False
+
 
 def load_env(env_path: str | None = None) -> None:
     """Load environment variables from a .env file once."""
@@ -41,10 +38,7 @@ def load_env(env_path: str | None = None) -> None:
     if _loaded:
         return
     if env_path is None:
-        # default to project root .env
         root_dir = Path(__file__).resolve().parents[1]
         env_path = root_dir / ".env"
     load_dotenv(env_path)
     _loaded = True
-
-    main

--- a/signal_pipeline/scan_volatility_signals.py
+++ b/signal_pipeline/scan_volatility_signals.py
@@ -9,14 +9,10 @@ import logging
 import argparse
 import sys
 from typing import List, Dict, Tuple
-from .config import load_env
+from .config import load_env, load_config
 from .gex_parser import parse_gex_comment
-codex/implement-unified-configuration-loader
-from .config import load_config
-=======
 
 load_env()
-main
 try:
     from textblob import TextBlob
     TEXTBLOB_AVAILABLE = True

--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -9,16 +9,10 @@ import os
 import matplotlib.pyplot as plt
 import argparse
 import json
-codex/implement-unified-configuration-loader
-from .config import load_config
-
-CONFIG = load_config()
-=======
-from .config import load_env
-main
-
+from .config import load_config, load_env
 from sentiment_score import classify_sentiment
 
+CONFIG = load_config()
 load_env()
 
 from functools import lru_cache

--- a/signal_pipeline/vol_signal_layer.py
+++ b/signal_pipeline/vol_signal_layer.py
@@ -105,17 +105,11 @@ def export_alerts(ticker, out_path=None, thresholds=None, fmt="json"):
     logging.info(f"Exported alerts to {out_path}")
     print(f"Exported alerts to {out_path}")
 def run_unit_tests():
-    print("Running unit tests...")
-    # Test load_latest_score
-    assert load_latest_score("GME") is None or isinstance(load_latest_score("GME"), dict)
-    # Test evaluate_signal
-    dummy = {"vol_container_score": 0.8}
-    res = evaluate_signal(dummy)
-    assert "score" in res and "alerts" in res
-    # Test batch_evaluate
-    batch = batch_evaluate(["GME", "AMC"])
-    assert isinstance(batch, dict)
-    print("All basic tests passed.")
+    """Execute the project's pytest suite."""
+    import pytest
+    test_dir = os.path.join(os.path.dirname(__file__), "..", "tests")
+    print("Running unit tests via pytest...")
+    pytest.main([test_dir])
 def run_api_server(host="127.0.0.1", port=5000):
     try:
         from flask import Flask, request, jsonify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_score_functions.py
+++ b/tests/test_score_functions.py
@@ -1,0 +1,21 @@
+import numpy as np
+from signal_pipeline.vol_container_score import calculate_iv_rank, calculate_score
+
+
+def test_calculate_iv_rank_basic():
+    history = [10, 20, 30, 40]
+    assert calculate_iv_rank(25, history) == 0.5
+    assert calculate_iv_rank(5, history) == 0.0
+    assert calculate_iv_rank(50, history) == 1.0
+
+
+def test_calculate_score_weights():
+    result = calculate_score(0.5, 0.2, 0.3, 0.1, 0.2)
+    expected = (
+        0.25 * 0.5 +
+        0.20 * 0.2 +
+        0.20 * 0.3 +
+        0.15 * 0.1 +
+        0.20 * 0.2
+    )
+    assert np.isclose(result, expected)

--- a/tests/test_sentiment_functions.py
+++ b/tests/test_sentiment_functions.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from signal_pipeline.sentiment_score import (
+    classify_sentiment,
+    score_dataframe,
+    batch_classify,
+    sentiment_summary,
+)
+
+
+def test_classify_sentiment_labels():
+    pol, label = classify_sentiment("Slow and steady wins")
+    assert label == "suppressing"
+    assert pol > 0
+
+    pol2, label2 = classify_sentiment("I'm bagholding again")
+    assert label2 == "breaking"
+    assert pol2 <= 0
+
+
+def test_score_dataframe_output():
+    df = pd.DataFrame({"title": ["slow and steady", "bagholding"]})
+    result = score_dataframe(df)
+    assert list(result.columns) == ["text", "polarity", "label"]
+    assert len(result) == 2
+    assert set(result["label"]) == {"suppressing", "breaking"}
+
+
+def test_batch_classify_and_summary():
+    texts = ["slow and steady", "bagholding"]
+    results = batch_classify(texts)
+    summary = sentiment_summary(results)
+    assert summary["label_counts"].get("suppressing") == 1
+    assert summary["label_counts"].get("breaking") == 1
+    assert summary["max"] >= summary["min"]


### PR DESCRIPTION
## Summary
- add pytest tests for `calculate_iv_rank` and `calculate_score`
- add pytest tests for sentiment scoring helpers
- install path hook for tests
- clean up merge artifacts and streamline `run_unit_tests`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cff6c6c48323b07b36257775788a