### PR TITLE
Fix logging setup

### DIFF
--- a/signal_pipeline/vol_container_score.py
+++ b/signal_pipeline/vol_container_score.py
@@ -11,6 +11,8 @@ from .scoring import (
     validate_config,
     send_email_alert,
     generate_pdf_report,
+    calculate_iv_rank,
+    calculate_score,
 )
 from .scoring import CONFIG
 

--- a/signal_pipeline/vol_signal_layer.py
+++ b/signal_pipeline/vol_signal_layer.py
@@ -11,7 +11,6 @@ from .utils import setup_logging
 SIGNAL_DIR = "data"
 DEFAULT_THRESHOLDS = {"high": 0.75, "low": 0.4}
 LOG_PATH = "logs/vol_signal_layer.log"
-os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
 setup_logging(LOG_PATH)
 
 def load_latest_score(ticker='GME'):


### PR DESCRIPTION
## Summary
- remove os.makedirs call in vol_signal_layer so utils handles logging
- export scoring helpers via vol_container_score for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891bc1ecdc83238f164938bcc60fcb